### PR TITLE
fix(qspi): unmap io1 pin in 4-wire cleanup macro

### DIFF
--- a/tuyaos/tuyaos_adapter/src/driver/tkl_qspi.c
+++ b/tuyaos/tuyaos_adapter/src/driver/tkl_qspi.c
@@ -65,6 +65,7 @@ static struct qspi_init_config qspi_infos[TUYA_QSPI_NUM_MAX] = {0};
 	if ((data_lines) == TUYA_QSPI_2WIRE) {\
 	    gpio_dev_unmap(QSPI##id##_LL_IO1_PIN);\
 	} else if ((data_lines) == TUYA_QSPI_4WIRE) {\
+	    gpio_dev_unmap(QSPI##id##_LL_IO1_PIN);\
 	    gpio_dev_unmap(QSPI##id##_LL_IO2_PIN);\
 	    gpio_dev_unmap(QSPI##id##_LL_IO3_PIN);\
 	} \


### PR DESCRIPTION
Made-with: Cursor