### PR TITLE
refactor(tuyaos-adapter): replace pinmux lookup table with direct fun…

### DIFF
--- a/tuyaos/tuyaos_adapter/src/driver/tkl_gpio.c
+++ b/tuyaos/tuyaos_adapter/src/driver/tkl_gpio.c
@@ -246,10 +246,3 @@ OPERATE_RET tkl_gpio_irq_disable(TUYA_GPIO_NUM_E pin_id)
     bk_gpio_disable_interrupt(pinmap[pin_id].gpio);
     return OPRT_OK;
 }
-
-gpio_id_t tkl_gpio_get_bk_gpio_id(TUYA_GPIO_NUM_E pin_id)
-{
-    PIN_DEV_CHECK_ERROR_RETURN(pin_id, GPIO_NUM);
-    
-    return pinmap[pin_id].gpio;
-}

--- a/tuyaos/tuyaos_adapter/src/driver/tkl_pinmux.c
+++ b/tuyaos/tuyaos_adapter/src/driver/tkl_pinmux.c
@@ -11,9 +11,9 @@
  * Included Files
  ****************************************************************************/
 
+#include "tuya_cloud_types.h"
 #include "tkl_pinmux.h"
 #include "driver/hal/hal_adc_types.h"
-#include <driver/gpio_types.h>
 
 /****************************************************************************
  * Pre-processor Definitions
@@ -22,31 +22,10 @@
 /****************************************************************************
  * Private Type Declarations
  ****************************************************************************/
-typedef struct{
-    TUYA_PIN_NAME_E pin;
-    TUYA_PIN_FUNC_E func;
-    gpio_dev_t      dev;
-}TUYA_PIN_FUNC_MAP_T;
+
 /****************************************************************************
  * Private Data Declarations
  ****************************************************************************/
-
-static TUYA_PIN_FUNC_MAP_T pin_func_map[] = {
-    {TUYA_IO_PIN_17,  TUYA_SPI0_MISO,      GPIO_DEV_SPI0_MISO},
-    {TUYA_IO_PIN_16,  TUYA_SPI0_MOSI,      GPIO_DEV_SPI0_MOSI},
-    {TUYA_IO_PIN_14,  TUYA_SPI0_CLK,       GPIO_DEV_SPI0_SCK},
-    {TUYA_IO_PIN_15,  TUYA_SPI0_CS,        GPIO_DEV_SPI0_CSN},
-    {TUYA_IO_PIN_2,   TUYA_SDIO_CLK,       GPIO_DEV_SDIO_HOST_CLK},
-    {TUYA_IO_PIN_3,   TUYA_SDIO_CMD,       GPIO_DEV_SDIO_HOST_CMD},
-    {TUYA_IO_PIN_4,   TUYA_SDIO_DATA0,     GPIO_DEV_SDIO_HOST_DATA0},
-    {TUYA_IO_PIN_5,   TUYA_SDIO_DATA1,     GPIO_DEV_SDIO_HOST_DATA1},
-    {TUYA_IO_PIN_6,   TUYA_SDIO_DATA2,     GPIO_DEV_SDIO_HOST_DATA2},
-    {TUYA_IO_PIN_7,   TUYA_SDIO_DATA3,     GPIO_DEV_SDIO_HOST_DATA3},
-    {TUYA_IO_PIN_30,  TUYA_UART2_RX,       GPIO_DEV_UART2_RXD},
-    {TUYA_IO_PIN_31,  TUYA_UART2_TX,       GPIO_DEV_UART2_TXD},
-    {TUYA_IO_PIN_20,  TUYA_IIC0_SCL,       GPIO_DEV_I2C0_SCL},
-    {TUYA_IO_PIN_21,  TUYA_IIC0_SDA,       GPIO_DEV_I2C0_SDA},
-};
 
 /****************************************************************************
  * Private Functions
@@ -57,19 +36,21 @@ static TUYA_PIN_FUNC_MAP_T pin_func_map[] = {
  ****************************************************************************/
 extern void __tkl_i2c_set_scl_pin(TUYA_I2C_NUM_E port, const TUYA_PIN_NAME_E scl_pin);
 extern void __tkl_i2c_set_sda_pin(TUYA_I2C_NUM_E port, const TUYA_PIN_NAME_E sda_pin);
-extern gpio_id_t tkl_gpio_get_bk_gpio_id(TUYA_GPIO_NUM_E pin_id);
 
-TUYA_PIN_FUNC_MAP_T *tkl_pinmux_get_func_map(TUYA_PIN_FUNC_E pin_func)
-{
-    for (int i = 0; i < sizeof(pin_func_map) / sizeof(TUYA_PIN_FUNC_MAP_T); i++) {
-        if (pin_func_map[i].func == pin_func) {
-            return &pin_func_map[i];
-        }
-    }
+extern void __tkl_uart2_set_rx_pin(TUYA_I2C_NUM_E port, const TUYA_PIN_NAME_E pin);
+extern void __tkl_uart2_set_tx_pin(TUYA_I2C_NUM_E port, const TUYA_PIN_NAME_E pin);
 
-    return NULL;
-}
+extern void __tkl_spi_set_cs_pin(TUYA_SPI_NUM_E port, TUYA_PIN_NAME_E pin);
+extern void __tkl_spi_set_clk_pin(TUYA_SPI_NUM_E port, TUYA_PIN_NAME_E pin);
+extern void __tkl_spi_set_mosi_pin(TUYA_SPI_NUM_E port, TUYA_PIN_NAME_E pin);
+extern void __tkl_spi_set_miso_pin(TUYA_SPI_NUM_E port, TUYA_PIN_NAME_E pin);
 
+extern void __tkl_sdio_set_clk_pin(TUYA_SDIO_NUM_E port, TUYA_PIN_NAME_E pin);
+extern void __tkl_sdio_set_cmd_pin(TUYA_SDIO_NUM_E port, TUYA_PIN_NAME_E pin);
+extern void __tkl_sdio_set_d0_pin(TUYA_SDIO_NUM_E port, TUYA_PIN_NAME_E pin);
+extern void __tkl_sdio_set_d1_pin(TUYA_SDIO_NUM_E port, TUYA_PIN_NAME_E pin);
+extern void __tkl_sdio_set_d2_pin(TUYA_SDIO_NUM_E port, TUYA_PIN_NAME_E pin);
+extern void __tkl_sdio_set_d3_pin(TUYA_SDIO_NUM_E port, TUYA_PIN_NAME_E pin);
 
 /**
  * @brief tuya io pinmux func
@@ -100,6 +81,42 @@ OPERATE_RET tkl_io_pinmux_config(TUYA_PIN_NAME_E pin, TUYA_PIN_FUNC_E pin_func)
         case TUYA_IIC2_SDA:
             __tkl_i2c_set_sda_pin(TUYA_I2C_NUM_2, pin);
             break;
+        case TUYA_UART2_RX:
+            __tkl_uart2_set_rx_pin(TUYA_UART_NUM_2, pin);
+            break;
+        case TUYA_UART2_TX:
+            __tkl_uart2_set_tx_pin(TUYA_UART_NUM_2, pin);
+            break;
+        case TUYA_SPI0_CLK:
+            __tkl_spi_set_clk_pin(TUYA_SPI_NUM_0, pin);
+            break;
+        case TUYA_SPI0_MOSI:
+            __tkl_spi_set_mosi_pin(TUYA_SPI_NUM_0, pin);
+            break;
+        case TUYA_SPI0_MISO:
+            __tkl_spi_set_miso_pin(TUYA_SPI_NUM_0, pin);
+            break;
+        case TUYA_SPI0_CS:
+            __tkl_spi_set_cs_pin(TUYA_SPI_NUM_0, pin);
+            break;
+        case TUYA_SDIO_CLK:
+            __tkl_sdio_set_clk_pin(TUYA_SDIO_NUM_0, pin);
+            break;
+        case TUYA_SDIO_CMD:
+            __tkl_sdio_set_cmd_pin(TUYA_SDIO_NUM_0, pin);
+            break;
+        case TUYA_SDIO_DATA0:
+            __tkl_sdio_set_d0_pin(TUYA_SDIO_NUM_0, pin);
+            break;
+        case TUYA_SDIO_DATA1:
+            __tkl_sdio_set_d1_pin(TUYA_SDIO_NUM_0, pin);
+            break;
+        case TUYA_SDIO_DATA2:
+            __tkl_sdio_set_d2_pin(TUYA_SDIO_NUM_0, pin);
+            break;
+        case TUYA_SDIO_DATA3:
+            __tkl_sdio_set_d3_pin(TUYA_SDIO_NUM_0, pin);
+            break;
 #if 0
         case TUYA_IIC3_SCL:
             __tkl_i2c_set_scl_pin(TUYA_I2C_NUM_3, pin);
@@ -120,29 +137,6 @@ OPERATE_RET tkl_io_pinmux_config(TUYA_PIN_NAME_E pin, TUYA_PIN_FUNC_E pin_func)
             __tkl_i2c_set_sda_pin(TUYA_I2C_NUM_5, pin);
             break;
 #endif
-
-        case TUYA_SPI0_MISO:
-        case TUYA_SPI0_MOSI:
-        case TUYA_SPI0_CLK: 
-        case TUYA_SPI0_CS:
-        case TUYA_SDIO_CLK:
-        case TUYA_SDIO_CMD:
-        case TUYA_SDIO_DATA0:
-        case TUYA_SDIO_DATA1:
-        case TUYA_SDIO_DATA2:
-        case TUYA_SDIO_DATA3:
-        case TUYA_UART2_RX:
-        case TUYA_UART2_TX: {
-            TUYA_PIN_FUNC_MAP_T *map = tkl_pinmux_get_func_map(pin_func);
-            if(map == NULL) {
-                bk_printf("pin_func %d not found\r\n", pin_func);
-                return OPRT_INVALID_PARM;
-            }
-
-            map->pin = pin;
-        }
-            break;
-            
         default:
             break;
 
@@ -225,15 +219,4 @@ int32_t tkl_io_pin_to_func(uint32_t pin, TUYA_PIN_TYPE_E pin_type)
     return port_channel;
 }
 
-gpio_id_t ty_get_dev_io(gpio_dev_t dev)
-{
-    TUYA_PIN_FUNC_MAP_T *map;
 
-    for (int i = 0; i < sizeof(pin_func_map) / sizeof(TUYA_PIN_FUNC_MAP_T); i++) {
-        if (pin_func_map[i].dev == dev) {
-            return tkl_gpio_get_bk_gpio_id(pin_func_map[i].pin);
-        }
-    }
-
-    return GPIO_NUM;
-}


### PR DESCRIPTION
…ction calls

Remove the pin_func_map lookup table and tkl_pinmux_get_func_map() in favor of calling peripheral-specific pin config functions directly for SPI, SDIO, and UART2. This matches the existing pattern used for I2C.

Also remove the now-unused tkl_gpio_get_bk_gpio_id() and ty_get_dev_io().