### PR TITLE
feat(network): implement tkl_net_getsockname and tkl_net_getpeername

### DIFF
--- a/tuyaos/tuyaos_adapter/src/system/tkl_network.c
+++ b/tuyaos/tuyaos_adapter/src/system/tkl_network.c
@@ -856,7 +856,27 @@ OPERATE_RET tkl_net_set_cloexec( const int fd)
 */
 OPERATE_RET tkl_net_getsockname(int fd, TUYA_IP_ADDR_T *addr, uint16_t *port)
 {
-    return 0;
+    if (fd < 0) {
+        return -3000 + fd;
+    }
+
+    struct sockaddr_in sock_addr;
+    socklen_t len = sizeof(struct sockaddr_in);
+
+    memset(&sock_addr, 0, sizeof(sock_addr));
+    if (getsockname(fd, (struct sockaddr *)&sock_addr, &len) < 0) {
+        return OPRT_COM_ERROR;
+    }
+
+    if (addr) {
+        *addr = TUYA_IP_ADDR_MAKE_IP4(ntohl(sock_addr.sin_addr.s_addr));
+    }
+
+    if (port) {
+        *port = ntohs((sock_addr.sin_port));
+    }
+
+    return OPRT_OK;
 }
 
 /**
@@ -886,7 +906,27 @@ OPERATE_RET tkl_net_set_broadcast(const int fd)
 */
 OPERATE_RET tkl_net_getpeername(int fd, TUYA_IP_ADDR_T *addr, uint16_t *port)
 {
-    return 0;
+    if (fd < 0) {
+        return -3000 + fd;
+    }
+
+    struct sockaddr_in sock_addr;
+    socklen_t len = sizeof(struct sockaddr_in);
+
+    memset(&sock_addr, 0, sizeof(sock_addr));
+    if (getpeername(fd, (struct sockaddr *)&sock_addr, &len) < 0) {
+        return OPRT_COM_ERROR;
+    }
+
+    if (addr) {
+        *addr = TUYA_IP_ADDR_MAKE_IP4(ntohl(sock_addr.sin_addr.s_addr));
+    }
+
+    if (port) {
+        *port = ntohs((sock_addr.sin_port));
+    }
+
+    return OPRT_OK;
 }
 char g_tkl_station_hostname[16] = {0};
 /**


### PR DESCRIPTION
Both returned 0 without touching the caller's buffers, so anything asking the platform which address a socket is bound or connected to silently got whatever the buffer already held.

ICE needs the bound port to build its host candidates: with the stub it advertised a garbage local candidate and the peer had nothing routable to answer, which stalled P2P negotiation.

Fill them from getsockname()/getpeername(), following the conventions the rest of this file already uses for socket helpers.