### PR TITLE
fix(tools): reuse the SDK's region instead of probing the network

### DIFF
--- a/tools/get_conutry.py
+++ b/tools/get_conutry.py
@@ -9,16 +9,13 @@ def get_country_code():
         code = os.environ.get("OPEN_COUNTRY_CODE", "")
         if code:
             MORROR = 1 if code == "China" else 2
-            print(MORROR)
-            return
-        try:
-            offset = datetime.datetime.now().astimezone().utcoffset()
-            if offset is not None and int(offset.total_seconds()) == 8 * 3600:
-                MORROR = 1
-            else:
+        else:
+            try:
+                offset = datetime.datetime.now().astimezone().utcoffset()
+                seconds = offset.total_seconds() if offset is not None else 0
+                MORROR = 1 if int(seconds) == 8 * 3600 else 2
+            except Exception:
                 MORROR = 2
-        except Exception:
-            MORROR = 2
 
     print(MORROR)
 

--- a/tools/get_conutry.py
+++ b/tools/get_conutry.py
@@ -1,8 +1,16 @@
 import datetime
+import os
+
 
 def get_country_code():
     global MORROR
     if MORROR == 0:
+        # Prefer the region the SDK already detected; see tools/util.py.
+        code = os.environ.get("OPEN_COUNTRY_CODE", "")
+        if code:
+            MORROR = 1 if code == "China" else 2
+            print(MORROR)
+            return
         try:
             offset = datetime.datetime.now().astimezone().utcoffset()
             if offset is not None and int(offset.total_seconds()) == 8 * 3600:

--- a/tools/util.py
+++ b/tools/util.py
@@ -2,9 +2,9 @@
 # coding=utf-8
 
 import os
+import datetime
 import platform
 import shutil
-import requests
 import hashlib
 import tarfile
 import zipfile
@@ -18,17 +18,27 @@ def set_country_code():
     if len(COUNTRY_CODE):
         return COUNTRY_CODE
 
+    # The SDK detects the region once and hands it down; a platform is a
+    # separate repository and cannot call into it. Any non-empty value is
+    # authoritative -- "Other" means overseas, not "unknown".
+    COUNTRY_CODE = os.environ.get("OPEN_COUNTRY_CODE", "")
+    if COUNTRY_CODE:
+        print(f"country code: {COUNTRY_CODE} (from SDK)")
+        return COUNTRY_CODE
+
+    # Older SDKs don't pass it. Infer from the timezone rather than asking
+    # a web service: choosing a download mirror must not itself depend on
+    # the network, and this keeps the prepare step free of third-party
+    # imports -- one of which used to break the build outright whenever
+    # the SDK invoked us with an interpreter that lacked it.
     try:
-        response = requests.get('http://www.ip-api.com/json', timeout=5)
-        response.raise_for_status()
-
-        result = response.json()
-        country = result.get("country", "")
-        print(f"country code: {country}")
-
-        COUNTRY_CODE = country
-    except requests.exceptions.RequestException as e:
+        offset = datetime.datetime.now().astimezone().utcoffset()
+        china = offset is not None and int(offset.total_seconds()) == 8 * 3600
+        COUNTRY_CODE = "China" if china else "Other"
+        print(f"country code: {COUNTRY_CODE} (from timezone)")
+    except Exception as e:
         print(f"country code error: {e}")
+        COUNTRY_CODE = "Other"
 
     return COUNTRY_CODE
 


### PR DESCRIPTION
## What

Stop probing a web service to decide which toolchain mirror to download from. Read the region the SDK already detected, and fall back to a timezone check rather than the network.

This drops the last use of `requests` outside `t5_os/`.

## Why

`tools/util.py` imported `requests` at module scope for a single call:

```python
response = requests.get('http://www.ip-api.com/json', timeout=5)
```

`tools/util.py` is imported by both `platform_prepare.py` and `build_example.py` before either does any work, so that one convenience turned a third-party package into a hard requirement of the entire prepare path. When the SDK invoked us with an interpreter that did not have it — on Windows a bare `python` resolves to uv's base interpreter under `.tools/python/<ver>/` rather than the SDK's `.venv` — prepare died with `ModuleNotFoundError: No module named 'requests'` before running a line of its own logic.

The SDK side of that is fixed separately (tuya/TuyaOpen, `fix/t5-build-env`), but the dependency should not have been on this path to begin with:

- The SDK already makes exactly this decision, and now hands the result down in `OPEN_COUNTRY_CODE`. We were re-deriving information we had been given.
- Choosing a **download** mirror should not itself depend on an external service being reachable. When `ip-api.com` was slow or blocked, the `except` swallowed it, `COUNTRY_CODE` stayed empty, and every user silently fell through to the overseas host — the exact case the CN mirror exists for.
- Every prepare paid up to a 5s timeout for information that is now free.

The toolchain download itself has always used `urllib.request`, so nothing else needed `requests`.

## Changes

**`tools/util.py`** — `set_country_code()` reads `OPEN_COUNTRY_CODE` first and treats any non-empty value as authoritative: `"Other"` means overseas, not "unknown" (an empty string is indistinguishable from unset, so the SDK exports a definite value). Older SDKs don't set it, so the fallback is the same timezone check the SDK uses. `import requests` removed.

**`tools/get_conutry.py`** — `toolchain_get.sh:49` makes the same decision through this script, so it honours the hand-off too and the two paths cannot disagree. Its timezone fallback is unchanged.

## Verification

`requests` is no longer reachable from the prepare path:

```
$ python3 -c "import sys, tools.util, tools.download_toolchain; print('requests' in sys.modules)"
False          # before this change: True
```

Region resolution and the mirror it selects:

| `OPEN_COUNTRY_CODE` | `get_country_code()` | `get_conutry.py` | toolchain host |
|---|---|---|---|
| unset | `China` (from timezone) | `1` | — |
| `China` | `China` (from SDK) | `1` | `images.tuyacn.com` |
| `Other` | `Other` (from SDK) | `2` | `armkeil.blob.core.windows.net` |

Timezone rows were produced in UTC+8; `download_toolchain.get_toolchain_package_info()` compares against `"China"`, so `"Other"` takes the overseas branch exactly as an empty string used to.

## Compatibility

Works unchanged against SDKs that do not set `OPEN_COUNTRY_CODE`. No change to the public shape of `get_country_code()` — the only difference visible to callers is that overseas now returns `"Other"` instead of `""`, and the sole comparison in this repo (`== "China"`) is unaffected.
